### PR TITLE
fixed "snippits" by updating context7 client api calls

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -98,7 +98,11 @@ impl Context7Client {
         CONTEXT7_MCP_URL
     }
 
-    pub async fn resolve_library(&self, library_name: &str) -> Result<(String, String)> {
+    pub async fn resolve_library(
+        &self,
+        library_name: &str,
+        query: &str,
+    ) -> Result<(String, String)> {
         // Always use MCP tools/call format for now
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
@@ -106,7 +110,8 @@ impl Context7Client {
             params: json!({
                 "name": "resolve-library-id",
                 "arguments": {
-                    "libraryName": library_name
+                    "libraryName": library_name,
+                    "query": query
                 }
             }),
             id: 1,
@@ -285,19 +290,17 @@ impl Context7Client {
 
     pub async fn get_documentation(&self, library_id: &str, topic: Option<&str>) -> Result<String> {
         let mut params = json!({
-            "context7CompatibleLibraryID": library_id
+            "libraryId": library_id
         });
 
-        if let Some(topic_str) = topic {
-            params["topic"] = json!(topic_str);
-        }
+        params["query"] = json!(topic.unwrap_or_default());
 
         // Always use MCP tools/call format for now
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             method: "tools/call".to_string(),
             params: json!({
-                "name": "get-library-docs",
+                "name": "query-docs",
                 "arguments": params
             }),
             id: 2,
@@ -320,6 +323,7 @@ impl Context7Client {
             .and_then(|text| text.as_str())
             .context("Failed to extract documentation from response")?;
 
+        log::debug!("{:?}", content);
         Ok(content.to_string())
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -57,7 +57,7 @@ impl SearchEngine {
         let (lib_name, _version) = parse_library_spec(library);
 
         // Step 1: Resolve library to Context7 ID
-        let (library_id, library_title) = self.client.resolve_library(lib_name).await?;
+        let (library_id, library_title) = self.client.resolve_library(lib_name, query).await?;
 
         // Step 2: Parse the query to extract phrases and terms
         let parsed_query = self.parse_search_query(query);
@@ -869,7 +869,10 @@ impl SearchEngine {
         let (lib_name, _version) = parse_library_spec(library);
 
         // Step 1: Resolve library to Context7 ID
-        let (library_id, _library_title) = self.client.resolve_library(lib_name).await?;
+        let (library_id, _library_title) = self
+            .client
+            .resolve_library(lib_name, query.unwrap_or(""))
+            .await?;
 
         // Step 2: Get documentation
         self.client.get_documentation(&library_id, query).await


### PR DESCRIPTION
The calls to context7 were using outdated api params, which was causing the "snippets" command not to work. Now snippets works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced library resolution to incorporate query context during search and documentation retrieval.
  * Updated documentation retrieval with refined RPC method handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->